### PR TITLE
The path in HASSIO_INSTALLER was deprecated. It was upgraded.

### DIFF
--- a/hassio_rpi3bp
+++ b/hassio_rpi3bp
@@ -15,7 +15,7 @@ set -o pipefail # Return exit status of the last command in the pipe that failed
 # GLOBALS
 # ==============================================================================
 readonly HOSTNAME="hassio"
-readonly HASSIO_INSTALLER="https://raw.githubusercontent.com/home-assistant/hassio-build/master/install/hassio_install"
+readonly HASSIO_INSTALLER="https://raw.githubusercontent.com/home-assistant/hassio-installer/master/hassio_install.sh"
 readonly REQUIREMENTS=(
   apparmor-utils
   apt-transport-https


### PR DESCRIPTION
The path for the Hassio installer was deprecated and the script fails. Therefore, it is necessary to change it to the new path: https://raw.githubusercontent.com/home-assistant/hassio-installer/master/hassio_install.sh
